### PR TITLE
Fix for when a component has no datasource defined

### DIFF
--- a/DeviceEditorForm.cs
+++ b/DeviceEditorForm.cs
@@ -246,11 +246,14 @@ namespace DeviceEditorShortcuts
                         xmlControl["HeaderID"] = obj.ID;
                         xmlControl["Placeholder"] = WebUtil.SafeEncode(renderingDefinition.Placeholder);
 
-                        var dataSourceItem = Client.ContentDatabase.GetItem(renderingDefinition.Datasource);
-                        if (dataSourceItem != null)
+                        if (!string.IsNullOrEmpty(renderingDefinition.Datasource))
                         {
-                            xmlControl["DataSourcePath"] = WebUtil.SafeEncode(dataSourceItem.Paths.FullPath);
-                            xmlControl["DataSourceID"] = WebUtil.SafeEncode(renderingDefinition.Datasource);
+                            var dataSourceItem = Client.ContentDatabase.GetItem(renderingDefinition.Datasource);
+                            if (dataSourceItem != null)
+                            {
+                                xmlControl["DataSourcePath"] = WebUtil.SafeEncode(dataSourceItem.Paths.FullPath);
+                                xmlControl["DataSourceID"] = WebUtil.SafeEncode(renderingDefinition.Datasource);
+                            }
                         }
                     }
                     else


### PR DESCRIPTION
It would YSOD with an Invalid Path from the .GetItem in some cases.
